### PR TITLE
fix(prompts): respond in the language of the user's question

### DIFF
--- a/src/utils/chat.utils.ts
+++ b/src/utils/chat.utils.ts
@@ -58,8 +58,8 @@ async function* streamAnthropicResponse(
     .filter((msg) => typeof msg.content === "string" && msg.content.length > 0);
 
   const lastMsgWithContext = selectionContext
-    ? `[Användaren hänvisar till följande markerade text:\n"${selectionContext}"]\n\n${lastMsgText}`
-    : lastMsgText;
+    ? `[Användaren hänvisar till följande markerade text:\n"${selectionContext}"]\n\nAnvändarens fråga: ${lastMsgText}`
+    : `Användarens fråga: ${lastMsgText}`;
 
   const conversationMessages: Anthropic.MessageParam[] = [
     ...history,
@@ -156,8 +156,8 @@ async function* streamGeminiResponse(
     .filter((msg) => msg.parts[0]?.text.length > 0);
 
   const lastMsgWithContext = selectionContext
-    ? `[Användaren hänvisar till följande markerade text:\n"${selectionContext}"]\n\n${lastMsgText}`
-    : lastMsgText;
+    ? `[Användaren hänvisar till följande markerade text:\n"${selectionContext}"]\n\nAnvändarens fråga: ${lastMsgText}`
+    : `Användarens fråga: ${lastMsgText}`;
 
   const lastUserTurn = {
     role: "user",

--- a/src/utils/prompts.ts
+++ b/src/utils/prompts.ts
@@ -1,4 +1,10 @@
 export const SYSTEM_PROMPT = `
+# Språk (allra viktigast — läs detta först)
+
+- Instruktionerna nedan är skrivna på svenska, men det styr INTE vilket språk du ska svara på.
+- Du MÅSTE alltid svara på samma språk som användarens senaste meddelande är skrivet på. Om användaren skriver på engelska, svara på engelska. Om användaren skriver på svenska, svara på svenska. Detta gäller oavsett vilket språk tentan, facit eller resten av denna systemprompt är på.
+- Byt svarsspråk om användaren byter språk mellan meddelanden.
+
 # Svarsstil (viktigt)
 
 - Fokusera på att förklara ordentligt. Prioritera en genomtänkt, pedagogisk förklaring som gör att studenten faktiskt förstår resonemanget och varför något stämmer, framför att fatta dig kort.


### PR DESCRIPTION
## Summary
- Weaker models (e.g. Gemini 3.1 Flash Lite) were answering in Swedish even when asked in English, because the system prompt is written almost entirely in Swedish and that dominated over a single embedded instruction.
- Moves the language rule to the very top of `SYSTEM_PROMPT` and states explicitly that the prompt's own language doesn't dictate the answer language — it must always match the user's latest message.
- Labels the actual question text with `Användarens fråga:` in both the Anthropic and Gemini message builders, so the model can unambiguously identify which part of the context is the question (vs. quoted selection text) to key its language off of.

## Test plan
- [ ] Ask a question in English on a Swedish exam with Gemini 3.1 Flash Lite — confirm English response
- [ ] Ask a question in Swedish — confirm Swedish response still works
- [ ] Verify Claude models (3.6/Sonnet) still respond correctly in both languages