### PR TITLE
Add OpenAI Terra and Luna chat models

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_SERVICE_KEY=your-service-key
 UPSTASH_REDIS_REST_URL=https://your-redis.upstash.io
 UPSTASH_REDIS_REST_TOKEN=your-redis-token
+OPENAI_API_KEY=your-openai-api-key
 ```
 
 ## Installation

--- a/src/api/v1/chat.models.ts
+++ b/src/api/v1/chat.models.ts
@@ -1,0 +1,41 @@
+export type Provider = "anthropic" | "google" | "openai";
+
+export interface ModelConfig {
+  provider: Provider;
+  modelId: string;
+}
+
+export const DEFAULT_MODEL_ID = "gpt-5.6-luna";
+
+const MODEL_MAP: Record<string, ModelConfig> = {
+  "gemini-3.1-flash-lite": {
+    provider: "google",
+    modelId: "gemini-3.1-flash-lite",
+  },
+  "gemini-3.6-flash": {
+    provider: "google",
+    modelId: "gemini-3.6-flash",
+  },
+  "claude-haiku-4-5": {
+    provider: "anthropic",
+    modelId: "claude-haiku-4-5",
+  },
+  "claude-sonnet-4-6": {
+    provider: "anthropic",
+    modelId: "claude-sonnet-4-6",
+  },
+  "gpt-5.6-terra": {
+    provider: "openai",
+    modelId: "gpt-5.6-terra",
+  },
+  "gpt-5.6-luna": {
+    provider: "openai",
+    modelId: "gpt-5.6-luna",
+  },
+};
+
+export const getModelConfig = (modelId?: string): ModelConfig =>
+  (modelId && MODEL_MAP[modelId]) ?? {
+    provider: "openai",
+    modelId: DEFAULT_MODEL_ID,
+  };

--- a/src/api/v1/chat.routes.ts
+++ b/src/api/v1/chat.routes.ts
@@ -14,44 +14,14 @@ import { supabase } from "~/db/supabase";
 import {
   streamAnthropicResponse,
   streamGeminiResponse,
+  streamOpenAIResponse,
   PdfData,
 } from "~/utils/chat.utils";
+import { getModelConfig } from "./chat.models";
 import {
   getAuthenticatedUserId,
   assertConversationOwnership,
 } from "~/utils/auth";
-
-type Provider = "anthropic" | "google";
-
-interface ModelConfig {
-  provider: Provider;
-  modelId: string;
-}
-
-const MODEL_MAP: Record<string, ModelConfig> = {
-  "gemini-3.1-flash-lite": {
-    provider: "google",
-    modelId: "gemini-3.1-flash-lite",
-  },
-  "gemini-3.6-flash": {
-    provider: "google",
-    modelId: "gemini-3.6-flash",
-  },
-  "claude-haiku-4-5": {
-    provider: "anthropic",
-    modelId: "claude-haiku-4-5",
-  },
-  "claude-sonnet-4-6": {
-    provider: "anthropic",
-    modelId: "claude-sonnet-4-6",
-  },
-};
-
-const getModelConfig = (modelId: string): ModelConfig =>
-  MODEL_MAP[modelId] ?? {
-    provider: "google",
-    modelId: "gemini-3.1-flash-lite",
-  };
 
 function extractTextContent(content: unknown): string {
   if (Array.isArray(content)) {
@@ -105,7 +75,7 @@ chat.post(
       solutionUrl,
       courseCode,
       conversationId,
-      modelId = "gemini-3.1-flash-lite",
+      modelId,
       selectionContext,
       giveDirectAnswer = true,
     } = body as any;
@@ -196,14 +166,23 @@ chat.post(
             selectionContext,
             cacheKey,
           )
-        : streamAnthropicResponse(
-            systemPrompt,
-            messages,
-            resolvedModelId,
-            pdfs,
-            lastMsgText,
-            selectionContext,
-          );
+        : provider === "anthropic"
+          ? streamAnthropicResponse(
+              systemPrompt,
+              messages,
+              resolvedModelId,
+              pdfs,
+              lastMsgText,
+              selectionContext,
+            )
+          : streamOpenAIResponse(
+              systemPrompt,
+              messages,
+              resolvedModelId,
+              pdfs,
+              lastMsgText,
+              selectionContext,
+            );
 
     return stream(c, async (s) => {
       c.header("Content-Type", "text/plain; charset=utf-8");

--- a/src/utils/chat.utils.ts
+++ b/src/utils/chat.utils.ts
@@ -1,6 +1,8 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { GoogleGenAI } from "@google/genai";
 import { LRUCache } from "lru-cache";
+import OpenAI from "openai";
+import type { ResponseInput } from "openai/resources/responses/responses";
 
 export interface PdfData {
   data: string;
@@ -20,6 +22,10 @@ const anthropic = new Anthropic({
 
 const googleAi = new GoogleGenAI({
   apiKey: process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY || "",
+});
+
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY || "",
 });
 
 const geminiCacheStore = new LRUCache<string, string>({
@@ -255,4 +261,97 @@ async function* streamGeminiResponse(
   }
 }
 
-export { streamAnthropicResponse, streamGeminiResponse };
+export function buildOpenAIInput(
+  messages: any[],
+  pdfs: PdfData[],
+  lastMsgText: string,
+  selectionContext?: string,
+): ResponseInput {
+  const history: ResponseInput = messages
+    .slice(0, -1)
+    .map((message: any) => {
+      const role = message?.role === "assistant" ? "assistant" : "user";
+      let content = "";
+
+      if (Array.isArray(message?.content)) {
+        content = message.content
+          .filter(
+            (part: any) =>
+              part?.type === "text" && typeof part?.text === "string",
+          )
+          .map((part: any) => part.text)
+          .join("\n");
+      } else if (typeof message?.content === "string") {
+        content = message.content;
+      }
+
+      return { role, content };
+    })
+    .filter(
+      (message) =>
+        typeof message.content === "string" && message.content.length > 0,
+    );
+
+  const lastMsgWithContext = selectionContext
+    ? `[Användaren hänvisar till följande markerade text:\n"${selectionContext}"]\n\nAnvändarens fråga: ${lastMsgText}`
+    : `Användarens fråga: ${lastMsgText}`;
+
+  const conversationMessages: ResponseInput = [
+    ...history,
+    { role: "user", content: lastMsgWithContext },
+  ];
+
+  if (pdfs.length === 0) return conversationMessages;
+
+  return [
+    {
+      role: "user",
+      content: pdfs.flatMap((pdf) => [
+        { type: "input_text" as const, text: getPdfLabelText(pdf.label) },
+        {
+          type: "input_file" as const,
+          filename: `${pdf.label}.pdf`,
+          file_data: `data:${pdf.mimeType};base64,${pdf.data}`,
+          detail: "auto" as const,
+        },
+      ]),
+    },
+    {
+      role: "assistant",
+      content: "Jag har läst igenom de bifogade filerna.",
+    },
+    ...conversationMessages,
+  ];
+}
+
+async function* streamOpenAIResponse(
+  systemPrompt: string,
+  messages: any[],
+  modelId: string,
+  pdfs: PdfData[],
+  lastMsgText: string,
+  selectionContext?: string,
+  client: Pick<OpenAI, "responses"> = openai,
+): AsyncGenerator<string> {
+  const responseStream = await client.responses.create({
+    model: modelId,
+    instructions: systemPrompt,
+    input: buildOpenAIInput(messages, pdfs, lastMsgText, selectionContext),
+    max_output_tokens: 16000,
+    reasoning: { effort: "low" },
+    store: false,
+    stream: true,
+  });
+
+  for await (const event of responseStream) {
+    if (event.type === "response.output_text.delta" && event.delta) {
+      yield event.delta;
+    }
+  }
+}
+
+export {
+  streamAnthropicResponse,
+  streamGeminiResponse,
+  streamOpenAIResponse,
+};

--- a/src/utils/prompts.ts
+++ b/src/utils/prompts.ts
@@ -7,7 +7,7 @@ export const SYSTEM_PROMPT = `
 
 # Svarsstil (viktigt)
 
-- Fokusera på att förklara ordentligt. Prioritera en genomtänkt, pedagogisk förklaring som gör att studenten faktiskt förstår resonemanget och varför något stämmer, framför att fatta dig kort.
+- Förklara pedagogiskt men koncist. Ta med de resonemang och beräkningssteg som behövs för förståelsen, utan att upprepa samma information eller skriva ut självklara mellanled.
 - Hoppa rakt in i svaret på det som faktiskt frågas, utan en inledande rubrik som bara upprepar eller sammanfattar frågan och utan en inledande artighetsfras.
 - Undvik en avslutande sammanfattningsruta eller punktlista som bara upprepar det som redan förklarats, om inte användaren uttryckligen ber om en sammanfattning.
 
@@ -17,8 +17,9 @@ export const SYSTEM_PROMPT = `
 
 ## Matematik (viktigt)
 
-- Skriv all matematik med KaTeX-kompatibel notation: korta variabler/symboler i löpande text med $...$, men alla viktiga ekvationer, beräkningssteg och härledningar MÅSTE placeras på egna rader som fristående block med $$...$$ (med en tomrad före och efter).
-- Tryck aldrig ihop längre formler eller beräkningskedjor i löpande text med $...$. Bryt alltid ut dem till egna $$...$$-block för luftig och tydlig struktur.
+- Skriv all matematik med KaTeX-kompatibel notation. Håll korta variabler, enkla uttryck och korta ekvationer i löpande text med $...$.
+- Använd fristående block med $$...$$ (med en tomrad före och efter) endast när en ekvation behöver betonas, är för lång för löpande text eller ingår i en flerstegshärledning.
+- Upprepa aldrig samma uttryck eller ekvation både i löpande text och i ett fristående matematikblock. Skriv den en gång i det format som passar bäst.
 - Använd aldrig \\( \\), \\[ \\] eller andra avgränsare.
 - Varje $ eller $$ som öppnas måste alltid stängas med matchande $ eller $$ innan du fortsätter med annan text.
 

--- a/tests/chat.models.test.ts
+++ b/tests/chat.models.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, mock } from "bun:test";
+import {
+  DEFAULT_MODEL_ID,
+  getModelConfig,
+} from "../src/api/v1/chat.models";
+import {
+  buildOpenAIInput,
+  streamOpenAIResponse,
+  type PdfData,
+} from "../src/utils/chat.utils";
+
+describe("chat model routing", () => {
+  it("routes Terra and Luna through OpenAI", () => {
+    expect(getModelConfig("gpt-5.6-terra")).toEqual({
+      provider: "openai",
+      modelId: "gpt-5.6-terra",
+    });
+    expect(getModelConfig("gpt-5.6-luna")).toEqual({
+      provider: "openai",
+      modelId: "gpt-5.6-luna",
+    });
+  });
+
+  it("falls back to Luna for omitted or unknown model IDs", () => {
+    expect(getModelConfig()).toEqual({
+      provider: "openai",
+      modelId: DEFAULT_MODEL_ID,
+    });
+    expect(getModelConfig("unknown-model")).toEqual({
+      provider: "openai",
+      modelId: DEFAULT_MODEL_ID,
+    });
+  });
+});
+
+describe("OpenAI chat streaming", () => {
+  const pdfs: PdfData[] = [
+    { data: "exam-data", mimeType: "application/pdf", label: "tenta" },
+    { data: "solution-data", mimeType: "application/pdf", label: "facit" },
+  ];
+
+  it("builds input with PDFs, history, and selection context", () => {
+    const input = buildOpenAIInput(
+      [
+        { role: "user", content: "Tidigare fråga" },
+        { role: "assistant", content: "Tidigare svar" },
+        { role: "user", content: "Ny fråga" },
+      ],
+      pdfs,
+      "Ny fråga",
+      "markerad text",
+    );
+
+    expect(input[0]).toMatchObject({ role: "user" });
+    expect((input[0] as any).content).toEqual([
+      expect.objectContaining({ type: "input_text" }),
+      {
+        type: "input_file",
+        filename: "tenta.pdf",
+        file_data: "data:application/pdf;base64,exam-data",
+        detail: "auto",
+      },
+      expect.objectContaining({ type: "input_text" }),
+      {
+        type: "input_file",
+        filename: "facit.pdf",
+        file_data: "data:application/pdf;base64,solution-data",
+        detail: "auto",
+      },
+    ]);
+    expect(input.slice(1)).toEqual([
+      { role: "assistant", content: "Jag har läst igenom de bifogade filerna." },
+      { role: "user", content: "Tidigare fråga" },
+      { role: "assistant", content: "Tidigare svar" },
+      {
+        role: "user",
+        content:
+          '[Användaren hänvisar till följande markerade text:\n"markerad text"]\n\nAnvändarens fråga: Ny fråga',
+      },
+    ]);
+  });
+
+  it("requests low-effort streaming and yields only text deltas", async () => {
+    const create = mock(async () =>
+      (async function* () {
+        yield { type: "response.created" };
+        yield { type: "response.output_text.delta", delta: "Hej" };
+        yield { type: "response.output_text.delta", delta: " världen" };
+        yield { type: "response.completed" };
+      })(),
+    );
+    const client = { responses: { create } } as any;
+
+    const chunks: string[] = [];
+    for await (const chunk of streamOpenAIResponse(
+      "Systemprompt",
+      [{ role: "user", content: "Fråga" }],
+      "gpt-5.6-luna",
+      [],
+      "Fråga",
+      undefined,
+      client,
+    )) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual(["Hej", " världen"]);
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "gpt-5.6-luna",
+        instructions: "Systemprompt",
+        max_output_tokens: 16000,
+        reasoning: { effort: "low" },
+        store: false,
+        stream: true,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add OpenAI Responses API streaming for GPT-5.6 Terra and Luna
- route supported chat models through a centralized provider map and default to Luna
- include PDFs, conversation history, and selected-text context in OpenAI requests
- make mathematical responses more concise and avoid repeated formulas
- document OPENAI_API_KEY and add routing/streaming tests

## Verification

- bun test (18 passing)
- bun run build